### PR TITLE
Fix Producer and Consumers

### DIFF
--- a/kafka-consumer/deployment.yaml
+++ b/kafka-consumer/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: kafka-consumer
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app: kafka-consumer

--- a/kafka-consumer/src/main/java/com/examples/java/vertx/kafka/consumer/ConsumerVerticle.java
+++ b/kafka-consumer/src/main/java/com/examples/java/vertx/kafka/consumer/ConsumerVerticle.java
@@ -50,6 +50,7 @@ public class ConsumerVerticle extends AbstractVerticle {
             order.setStatus(OrderStatus.SHIPPED);
             order.setProcessedTime(Instant.now());
             //TODO: Add code to simulate a delay.
+            //TODO: Add code to commit since auto-commit is set to "false"
             LOGGER.info("Order processed: id={}, price={}, timeTaken={}", order.getId(), order.getPrice(), Duration.between(order.getCreatedTime(), order.getProcessedTime()).toMillis());
         });
     }

--- a/kafka-producer/src/main/java/com/examples/java/vertx/kafka/producer/ProducerVerticle.java
+++ b/kafka-producer/src/main/java/com/examples/java/vertx/kafka/producer/ProducerVerticle.java
@@ -61,8 +61,8 @@ public class ProducerVerticle extends AbstractVerticle {
 
             for (Object order : orderList) {
                 JsonObject orderJson = JsonObject.mapFrom(order);
-
-                KafkaProducerRecord<String, JsonObject> record = KafkaProducerRecord.create(Constants.KAFKA_ORDERS_TOPIC, orderJson.getString("id"), orderJson, 0);
+                //Distribute the messages evenly around the partitions.
+                KafkaProducerRecord<String, JsonObject> record = KafkaProducerRecord.create(Constants.KAFKA_ORDERS_TOPIC,orderJson);
                 producer.write(record, done -> {
                     if (done.succeeded()) {
                         RecordMetadata recordMetadata = done.result();

--- a/kafka-scaled-object.yaml
+++ b/kafka-scaled-object.yaml
@@ -2,7 +2,7 @@ apiVersion: keda.k8s.io/v1alpha1
 kind: ScaledObject
 metadata:
   name: kafka-scaledobject
-  namespace: default
+  namespace: keda
   labels:
     deploymentName: kafka-consumer-deployment # Required Name of the deployment we want to scale.
 spec:


### PR DESCRIPTION
1. kafka-consumer deployment is "0" replicas
2.  in kafka-scaledobject.yaml you need to use the keda namesapce not the default namesapce
3. I dont see a code for commit the consumer offset in the Consumer code -> changed it to be auto-commit since this is not the focus of this article.
4. if you create a topic with single partition there is not much meaning to scaling here - you always send to partition "0" -> again , this is not scalable and there is no much sense in scaling more pods since only 1 pod will be able to read from it.
