### PR TITLE
Fix/autoscaling

### DIFF
--- a/kafka-consumer/src/main/java/com/examples/java/vertx/kafka/consumer/ConsumerVerticle.java
+++ b/kafka-consumer/src/main/java/com/examples/java/vertx/kafka/consumer/ConsumerVerticle.java
@@ -33,7 +33,7 @@ public class ConsumerVerticle extends AbstractVerticle {
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.GROUP_ID_CONFIG, "order-shipper");
         config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
-        config.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        config.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
 
         KafkaConsumer<String, String> consumer = KafkaConsumer.create(vertx, config);
         consumer.subscribe(Constants.KAFKA_ORDERS_TOPIC, ar -> {
@@ -50,7 +50,6 @@ public class ConsumerVerticle extends AbstractVerticle {
             order.setStatus(OrderStatus.SHIPPED);
             order.setProcessedTime(Instant.now());
             //TODO: Add code to simulate a delay.
-            //TODO: Add code to commit since auto-commit is set to "false"
             LOGGER.info("Order processed: id={}, price={}, timeTaken={}", order.getId(), order.getPrice(), Duration.between(order.getCreatedTime(), order.getProcessedTime()).toMillis());
         });
     }

--- a/kafka-scaled-object.yaml
+++ b/kafka-scaled-object.yaml
@@ -2,7 +2,7 @@ apiVersion: keda.k8s.io/v1alpha1
 kind: ScaledObject
 metadata:
   name: kafka-scaledobject
-  namespace: keda
+  namespace: default
   labels:
     deploymentName: kafka-consumer-deployment # Required Name of the deployment we want to scale.
 spec:


### PR DESCRIPTION
Hi @ChamilaLiyanage! First of all, thanks for writing the article that really helped me understand how KEDA works. It is very detailed and I was able to follow the steps easily. Just wanted to contribute back to the guys who face a little hiccup on getting the autoscaling working. Minor issues on autoscaling that I faced:

* CRD `ScaledObject` not created in the correct namespace, thus causing hpa not to be created
* hpa not able to scale deployment down because there is no commit back to kafka from consumer. Did a change to simply enable autocommit that so that users could use this boilerplate without code change